### PR TITLE
Update spectrum.js - memleak w/flat option

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -662,13 +662,14 @@
         }
 
         function hide() {
-            // Return if hiding is unnecessary
-            if (!visible || flat) { return; }
-            visible = false;
-
+            // always unbind handlers
             $(doc).unbind("keydown.spectrum", onkeydown);
             $(doc).unbind("click.spectrum", clickout);
             $(window).unbind("resize.spectrum", resize);
+
+            // Return if hiding is unnecessary
+            if (!visible || flat) { return; }
+            visible = false;
 
             replacer.removeClass("sp-active");
             container.addClass("sp-hidden");


### PR DESCRIPTION
See: Issue#344 - https://github.com/bgrins/spectrum/issues/344

Memory leak occurs if "flat" option is used and spectrum is added/removed dynamically from the page.  The early return from hide() was causing listeners to pin the detached DOM nodes. 

Moving the unbind() calls above the early return to ensure handlers are always removed.  

Making subsequent PR to update unit tests to validate listeners are removed. Will be independent to this transaction as test will simply focus on ensuring handlers are removed on hide. 
